### PR TITLE
🐞 fix(layouts): fix partials/ error

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -22,7 +22,7 @@
   {{ end }}
   <div id="container">
     <div id="wrap">
-      {{ partial "partials/header.html" (merge (dict "Page" .) (dict "Site" .Site) (dict "Type" "404")) }}
+      {{ partial "header.html" (merge (dict "Page" .) (dict "Site" .Site) (dict "Type" "404")) }}
     </div>
   </div>
   

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,3 +1,3 @@
 {{ define "main" }}
-  {{ partial "partials/article.html" . }}
+  {{ partial "article.html" . }}
 {{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -4,9 +4,9 @@
     data-aos="{{ .Site.Params.animation.options.archive.whole }}"
   >
     {{ if not .Site.Params.only_show_capsule_in_index }}
-      {{ partialCached "partials/archives.html" . }}
+      {{ partialCached "archives.html" . }}
     {{ end }}
     {{ .Render "list" }}
   </div>
-  {{ partial "partials/pagination.html" . }}
+  {{ partial "pagination.html" . }}
 {{ end }}

--- a/layouts/archives/section.html
+++ b/layouts/archives/section.html
@@ -3,8 +3,8 @@
     class="archives-outer-wrap"
     data-aos="{{ .Site.Params.animation.options.archive.whole }}"
   >
-    {{ partialCached "partials/archives.html" . }}
+    {{ partialCached "archives.html" . }}
     {{ .Render "list" }}
   </div>
-  {{ partial "partials/pagination.html" . }}
+  {{ partial "pagination.html" . }}
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -42,7 +42,7 @@
     </div>
   {{ end }}
   {{ range $k, $v := $paginator.Pages }}
-    {{ partial "partials/post.html"  (dict "index" $k "ctx" . "page" $v ) }}
+    {{ partial "post.html"  (dict "index" $k "ctx" . "page" $v ) }}
   {{ end }}
-  {{ partial "partials/pagination.html" . }}
+  {{ partial "pagination.html" . }}
 {{ end }}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -135,4 +135,4 @@
     {{ partial "post/nav.html" . }}
   {{ end }}
 </article>
-{{ partial "partials/comment.html" . }}
+{{ partial "comment.html" . }}


### PR DESCRIPTION
Starting with Hugo v0.146.0, using the partials/ prefix in a call like:
```
{{ partial "partials/foo.html" }}
```
will cause
```
WARN  Partial name "partials/foo.html" starting with 'partials/' (as in {{ partial "partials/foo.html"}}) is most likely not what you want. Before 0.146.0 we did a double lookup in this situation. 
You can suppress this warning by adding the following to your site configuration: 
ignoreLogs = ['warning-partial-superfluous-prefix']
```
and throw out an error:
```
Error: ... error calling partial: partial "partials/foo" not found
```