### PR TITLE
feat: support multi-language RSS output

### DIFF
--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -151,9 +151,13 @@ only_show_capsule_in_index: false # If you have hugo amounts of tags and categor
 # RSS output
 rss:
   limit: 10             # The number of recent articles to be output, write -1 to output all
-  showFullContent: false # output full content or description
-  showCopyright: false   # If true, add copyright to the end of article.
-  copyright: "All website licensed under CC BY 4.0" # Only plain text is allowed.
+  showFullContent: true # output full content or description
+  showCopyright: true   # If true, add copyright to the end of article.
+  copyright:            # Only plain text is allowed.
+    en: "Unless otherwise stated, all posts on this blog are licensed under the BY-NC-SA license. Please credit the source when reposting!"
+    zh_cn: "本博客所有文章除特别声明外，均采用 BY-NC-SA 许可协议。转载请注明出处！"
+    zh_tw: "本部落格所有文章除特別聲明外，皆採用 BY-NC-SA 授權條款。轉載請註明出處！"
+    ja: "特別な記載がない限り、このブログのすべての記事は BY-NC-SA ライセンスの下で提供されています。転載の際は出典を明記してください！"
 
 ########################################
 # CSS

--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -151,8 +151,8 @@ only_show_capsule_in_index: false # If you have hugo amounts of tags and categor
 # RSS output
 rss:
   limit: 10             # The number of recent articles to be output, write -1 to output all
-  showFullContent: true # output full content or description
-  showCopyright: true   # If true, add copyright to the end of article.
+  showFullContent: false # output full content or description
+  showCopyright: false   # If true, add copyright to the end of article.
   copyright:            # Only plain text is allowed.
     en: "Unless otherwise stated, all posts on this blog are licensed under the BY-NC-SA license. Please credit the source when reposting!"
     zh_cn: "本博客所有文章除特别声明外，均采用 BY-NC-SA 许可协议。转载请注明出处！"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -4,104 +4,124 @@
 {{- $authorName := "" }}
 {{- /* 从站点参数中获取作者信息 */ -}}
 {{- with site.Params }}
-  {{- /* 检查作者信息是否是键值对形式 */ -}}
   {{- if reflect.IsMap . }}
-    {{- /* 获取作者邮箱 */ -}}
     {{- with .email }}{{ $authorEmail = . }}{{ end }}
-    {{- /* 获取作者姓名 */ -}}
     {{- with .author }}{{ $authorName = . }}{{ end }}
   {{- else }}
-    {{- /* 如果作者信息是字符串，直接作为作者姓名 */ -}}
     {{- $authorName = . }}
   {{- end }}
 {{- end }}
 
-{{- /* 获取是否显示全文的设置，默认为false */ -}}
 {{- $showFullContent := .Site.Params.rss.showFullContent | default false }}
-{{- /* 获取是否显示版权的设置，默认为false */ -}}
 {{- $showCopyright := .Site.Params.rss.showCopyright | default false }}
-{{- /* 获取当前语言（兼容单语言/多语言站点） */ -}}
 {{- $currentLanguage := .Language.Lang | default "en" }}
 
-{{- /* 确定页面上下文：如果是首页使用站点对象，否则使用当前页面对象 */ -}}
+{{- /* 修正语言标识符处理 */ -}}
+{{- $lang := replace $currentLanguage "-" "_" | lower }}
+
+{{- /* 获取多语言版权信息 */ -}}
+{{- $copyright := "" }}
+{{- with .Site.Params.rss.copyright }}
+  {{- if eq $lang "en" }}
+    {{- $copyright = .en }}
+  {{- else if eq $lang "zh_cn" }}
+    {{- $copyright = .zh_cn }}
+  {{- else if eq $lang "zh_tw" }}
+    {{- $copyright = .zh_tw }}
+  {{- else if eq $lang "ja" }}
+    {{- $copyright = .ja }}
+  {{- else }}
+    {{- $copyright = .en }}
+  {{- end }}
+{{- else }}
+  {{- $copyright = "All website licensed under CC BY 4.0" }}
+{{- end }}
+
+{{- /* 确定页面上下文 */ -}}
 {{- $pctx := . }}
 {{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
-{{- /* 动态获取多语言状态（兼容 Hugo v0.124.0+） */ -}}
 {{- $pages := $pctx.RegularPages }}
+{{- $mainSections := .Site.MainSections }}
+{{- $pages = where $pages "Section" "in" $mainSections }}
 {{- if hugo.IsMultilingual }}
   {{- $pages = where $pages "Language.Lang" $currentLanguage }}
 {{- end }}
-{{- /* 按最后修改时间排序 */ -}}
-{{- $pages = $pages.ByLastmod.Reverse }}
 
-{{- /* 获取RSS条目数量限制，默认10条（-1 表示不限制） */ -}}
+{{- $pages = $pages.ByLastmod.Reverse }}
 {{- $limit := .Site.Params.rss.limit | default 10 }}
-{{- /* 如果限制数大于等于1，则只取前N条 */ -}}
 {{- if ge $limit 1 }}
   {{- $pages = $pages | first $limit }}
 {{- end }}
 
-{{- /* 输出XML声明 */ -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    {{- /* 频道标题：如果是首页显示站点标题，否则显示"页面标题 on 站点标题" */ -}}
     <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content from {{ .Site.Title }}</description>
     <generator>Hugo</generator>
     <language>{{ site.Language.LanguageCode }}</language>
-    {{- /* 输出管理员和站长信息（带邮箱和姓名） */ -}}
     {{ with $authorEmail }}
     <managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>
     <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>
     {{ end }}
-    {{- /* 输出版权信息 */ -}}
-    {{ with .Site.Params.Rss.Copyright }}
-    <copyright>{{ . | default "All website licensed under CC BY 4.0" }}</copyright>
-    {{ end }}
-    {{- /* 输出最后构建日期（使用最新修改的文章日期） */ -}}
+    <copyright>{{ $copyright }}</copyright>
     {{ if not .Date.IsZero }}
     <lastBuildDate>{{ (index $pages 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{ end }}
-    {{- /* 输出RSS源的自我链接 */ -}}
     {{ with .OutputFormats.Get "RSS" }}
     <atom:link href="{{ .Permalink }}" rel="self" type="{{ .MediaType }}" />
     {{ end }}
 
-    {{- /* 遍历所有筛选后的文章 */ -}}
     {{ range $pages }}
-    {{- /* 构建文章头部 */ -}}
-    {{ $articleHeader := printf "<![CDATA[<h1>%s</h1><p>作者: %s (%s)</p>" .Title $authorName $authorEmail }}
-    
-    {{- /* 构建文章尾部 */ -}}
-    {{ $articleFooter := printf "<hr><p>本文 %s 首发于 <a href='%s'>%s</a>，最后修改于 %s</p>" (.Date.Format "2006-01-02") .Site.BaseURL .Site.Title (.Lastmod.Format "2006-01-02") }}
-    {{ if $showCopyright }}
-      {{ $articleFooter = printf "%s<p>%s</p>" $articleFooter .Site.Params.Rss.Copyright }}
-    {{ end }}
+    {{- /* 构建多语言文章头部 */ -}}
+    {{ $articleHeader := "" }}
+    {{- if eq $lang "en" }}
+      {{ $articleHeader = printf "<![CDATA[<h1>%s</h1><p>Author: %s (%s)</p>" .Title $authorName $authorEmail }}
+    {{- else if eq $lang "zh_cn" }}
+      {{ $articleHeader = printf "<![CDATA[<h1>%s</h1><p>作者：%s（%s）</p>" .Title $authorName $authorEmail }}
+    {{- else if eq $lang "zh_tw" }}
+      {{ $articleHeader = printf "<![CDATA[<h1>%s</h1><p>作者：%s（%s）</p>" .Title $authorName $authorEmail }}
+    {{- else if eq $lang "ja" }}
+      {{ $articleHeader = printf "<![CDATA[<h1>%s</h1><p>著者：%s（%s）</p>" .Title $authorName $authorEmail }}
+    {{- end }}
+
+    {{- /* 构建多语言文章尾部 */ -}}
+    {{ $articleFooter := "" }}
+    {{- if eq $lang "en" }}
+      {{ $articleFooter = printf "<hr><p>Published on %s at <a href='%s'>%s</a>, last modified on %s</p>"
+        (.Date.Format "2006-01-02") .Site.BaseURL .Site.Title (.Lastmod.Format "2006-01-02") }}
+    {{- else if eq $lang "zh_cn" }}
+      {{ $articleFooter = printf "<hr><p>本文 %s 首发于 <a href='%s'>%s</a>，最后修改于 %s</p>"
+        (.Date.Format "2006-01-02") .Site.BaseURL .Site.Title (.Lastmod.Format "2006-01-02") }}
+    {{- else if eq $lang "zh_tw" }}
+      {{ $articleFooter = printf "<hr><p>本文 %s 首發於 <a href='%s'>%s</a>，最後修改於 %s</p>"
+        (.Date.Format "2006-01-02") .Site.BaseURL .Site.Title (.Lastmod.Format "2006-01-02") }}
+    {{- else if eq $lang "ja" }}
+      {{ $articleFooter = printf "<hr><p>この記事は%sに<a href='%s'>%s</a>で公開され、最終更新日は%sです</p>"
+        (.Date.Format "2006-01-02") .Site.BaseURL .Site.Title (.Lastmod.Format "2006-01-02") }}
+    {{- end }}
+
+    {{- if $showCopyright }}
+      {{ $articleFooter = printf "%s<p>%s</p>" $articleFooter $copyright }}
+    {{- end }}
     {{ $articleFooter = printf "%s]]>" $articleFooter }}
-    
+
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
-      {{- /* 输出作者信息 */ -}}
       {{ with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
       <description>
-        {{- /* 输出文章头部 */ -}}
         {{ $articleHeader | safeHTML }}
-        {{- /* 根据设置输出全文或摘要 */ -}}
         {{ if $showFullContent }}
           {{ .Content | safeHTML }}
         {{ else }}
           {{ .Summary | safeHTML }}
         {{ end }}
-        {{- /* 输出文章尾部 */ -}}
         {{ $articleFooter | safeHTML }}
       </description>
-
-      {{- /* 输出文章分类 */ -}}
       {{ with .Params.categories }}
         {{ range . }}<category>{{ . }}</category>{{ end }}
       {{ end }}


### PR DESCRIPTION
根据当前网站语言输出对应语言版本RSS内容。

对 `<item><description>` 首尾插入信息多语言适配，例如：  

`ja`  
```xml
<p>著者：孤筝（lvbowen040427@163.com）</p>

<hr><p>この記事は2025-04-19に<a href='https://guzhengsvt.cn/'>孤筝の温暖小家</a>で公開され、最終更新日は2025-04-19です</p><p>特別な記載がない限り、このブログのすべての記事は BY-NC-SA ライセンスの下で提供されています。転載の際は出典を明記してください！</p>
```


`en`  
```xml
<p>Author: 孤筝 (lvbowen040427@163.com)</p>

<hr><p>Published on 2025-04-19 at <a href='https://guzhengsvt.cn/'>孤筝の温暖小家</a>, last modified on 2025-04-19</p><p>Unless otherwise stated, all posts on this blog are licensed under the BY-NC-SA license. Please credit the source when reposting!</p>
```


`params.yml` 中可自定义 `zh-cn,zh-tw,en,ja` 的 `copyright`  
```yml
# RSS output
rss:
  limit: 10             # The number of recent articles to be output, write -1 to output all
  showFullContent: true # output full content or description
  showCopyright: true   # If true, add copyright to the end of article.
  copyright:            # Only plain text is allowed.
    en: "Unless otherwise stated, all posts on this blog are licensed under the BY-NC-SA license. Please credit the source when reposting!"
    zh_cn: "本博客所有文章除特别声明外，均采用 BY-NC-SA 许可协议。转载请注明出处！"
    zh_tw: "本部落格所有文章除特別聲明外，皆採用 BY-NC-SA 授權條款。轉載請註明出處！"
    ja: "特別な記載がない限り、このブログのすべての記事は BY-NC-SA ライセンスの下で提供されています。転載の際は出典を明記してください！"
```
