### PR TITLE
添加侧边栏tag和category的跳转

### DIFF
--- a/assets/css/partials/sidebar.scss
+++ b/assets/css/partials/sidebar.scss
@@ -132,6 +132,11 @@
   }
 }
 
+.sidebar-state a {
+  text-decoration: none;
+  color: inherit;
+}
+
 .sidebar-state-article {
   @include sidebar-state-content;
   border-right: 1px solid var(--red-1);

--- a/layouts/partials/sidebar/commonBar.html
+++ b/layouts/partials/sidebar/commonBar.html
@@ -15,14 +15,12 @@
     {{- $posts := (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) -}}
     <div class="sidebar-state-number">{{ len $posts }}</div>
   </div>
-  <div class="sidebar-state-category">
-    <a class="sidebar-state-category" href="{{ "categories/" | relLangURL }}" aria-label="">
+  <a class="sidebar-state-category" href="{{ "categories/" | relLangURL }}" aria-label="">
     <div>{{ i18n "sidebar.category" }}</div>
     <div class="sidebar-state-number">
       {{ len .Site.Taxonomies.categories }}
     </div>
-    </a>
-  </div>
+  </a>
   <a class="sidebar-state-tag" href="{{ "tags/" | relLangURL }}" aria-label="">
     <div>{{ i18n "sidebar.tag" }}</div>
     <div class="sidebar-state-number">{{ len .Site.Taxonomies.tags }}</div>

--- a/layouts/partials/sidebar/commonBar.html
+++ b/layouts/partials/sidebar/commonBar.html
@@ -15,13 +15,13 @@
     {{- $posts := (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) -}}
     <div class="sidebar-state-number">{{ len $posts }}</div>
   </div>
-  <a class="sidebar-state-category" href="{{ "categories/" | relLangURL }}" aria-label="">
+  <a class="sidebar-state-category" href="{{ "categories/" | relLangURL }}" aria-label="sidebar-state-category-link">
     <div>{{ i18n "sidebar.category" }}</div>
     <div class="sidebar-state-number">
       {{ len .Site.Taxonomies.categories }}
     </div>
   </a>
-  <a class="sidebar-state-tag" href="{{ "tags/" | relLangURL }}" aria-label="">
+  <a class="sidebar-state-tag" href="{{ "tags/" | relLangURL }}" aria-label="sidebar-state-tag-link">
     <div>{{ i18n "sidebar.tag" }}</div>
     <div class="sidebar-state-number">{{ len .Site.Taxonomies.tags }}</div>
   </a>

--- a/layouts/partials/sidebar/commonBar.html
+++ b/layouts/partials/sidebar/commonBar.html
@@ -16,17 +16,19 @@
     <div class="sidebar-state-number">{{ len $posts }}</div>
   </div>
   <div class="sidebar-state-category">
-    <a class="sidebar-state-link" href="{{ "categories/" | relLangURL }}" aria-label=""></a>
+    <a class="sidebar-state-link" href="{{ "categories/" | relLangURL }}" aria-label="">
     <div>{{ i18n "sidebar.category" }}</div>
     <div class="sidebar-state-number">
       {{ len .Site.Taxonomies.categories }}
     </div>
+    </a>
   </div>
   <div class="sidebar-state-tag">
-    <a class="sidebar-state-link" href="{{ "tags/" | relLangURL }}" aria-label=""></a>
+    <a class="sidebar-state-link" href="{{ "tags/" | relLangURL }}" aria-label="">
     <div>{{ i18n "sidebar.tag" }}</div>
     <div class="sidebar-state-number">{{ len .Site.Taxonomies.tags }}</div>
   </div>
+  </a>
 </div>
 <div class="sidebar-social">
   {{- range $name, $url := .Site.Params.social -}}

--- a/layouts/partials/sidebar/commonBar.html
+++ b/layouts/partials/sidebar/commonBar.html
@@ -16,12 +16,14 @@
     <div class="sidebar-state-number">{{ len $posts }}</div>
   </div>
   <div class="sidebar-state-category">
+    <a class="sidebar-state-link" href="{{ "categories/" | relLangURL }}" aria-label=""></a>
     <div>{{ i18n "sidebar.category" }}</div>
     <div class="sidebar-state-number">
       {{ len .Site.Taxonomies.categories }}
     </div>
   </div>
   <div class="sidebar-state-tag">
+    <a class="sidebar-state-link" href="{{ "tags/" | relLangURL }}" aria-label=""></a>
     <div>{{ i18n "sidebar.tag" }}</div>
     <div class="sidebar-state-number">{{ len .Site.Taxonomies.tags }}</div>
   </div>

--- a/layouts/partials/sidebar/commonBar.html
+++ b/layouts/partials/sidebar/commonBar.html
@@ -16,18 +16,16 @@
     <div class="sidebar-state-number">{{ len $posts }}</div>
   </div>
   <div class="sidebar-state-category">
-    <a class="sidebar-state-link" href="{{ "categories/" | relLangURL }}" aria-label="">
+    <a class="sidebar-state-category" href="{{ "categories/" | relLangURL }}" aria-label="">
     <div>{{ i18n "sidebar.category" }}</div>
     <div class="sidebar-state-number">
       {{ len .Site.Taxonomies.categories }}
     </div>
     </a>
   </div>
-  <div class="sidebar-state-tag">
-    <a class="sidebar-state-link" href="{{ "tags/" | relLangURL }}" aria-label="">
+  <a class="sidebar-state-tag" href="{{ "tags/" | relLangURL }}" aria-label="">
     <div>{{ i18n "sidebar.tag" }}</div>
     <div class="sidebar-state-number">{{ len .Site.Taxonomies.tags }}</div>
-  </div>
   </a>
 </div>
 <div class="sidebar-social">


### PR DESCRIPTION
无意间发现/tags/和/categories/也会渲染页面，就想这边是不是可以跳转过来

不是很会写html