### PR TITLE
Add time reverse sort order

### DIFF
--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -156,8 +156,8 @@ rss:
 
 # Sort order configuration
 # Available values: time, time-reverse, weight, weight-reverse
-# time: sorted by time in ascending order (default)
-# time-reverse: sorted by time in descending order
+# time: sorted by time in descending order (newest first)
+# time-reverse: sorted by time in ascending order (oldest first, default)
 # weight: sorted by weight in ascending order
 # weight-reverse: sorted by weight in descending order
 sort_order:

--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -155,10 +155,11 @@ rss:
   showCopyright: false   # If true, add copyright to the end of article.
 
 # Sort order configuration
-# Available values: time, weight, weight-reverse
-# time: default
+# Available values: time, time-reverse, weight, weight-reverse
+# time: sorted by time in ascending order (default)
+# time-reverse: sorted by time in descending order
 # weight: sorted by weight in ascending order
-# weight_reverse: sorted by weight in descending order
+# weight-reverse: sorted by weight in descending order
 sort_order:
   taxonomy:
     category: time # controlled by categories_weight

--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -156,8 +156,8 @@ rss:
 
 # Sort order configuration
 # Available values: time, time-reverse, weight, weight-reverse
-# time: sorted by time in descending order (newest first)
-# time-reverse: sorted by time in ascending order (oldest first, default)
+# time: sorted by time in descending order (newest first, default)
+# time-reverse: sorted by time in ascending order (oldest first)
 # weight: sorted by weight in ascending order
 # weight-reverse: sorted by weight in descending order
 sort_order:

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -14,7 +14,7 @@
   {{- else if eq $sort_config "weight-reverse" -}}
     {{- $paginator = .Paginator.Pages.ByWeight.Reverse -}}
   {{- else if eq $sort_config "time-reverse" -}}
-    {{- $paginator = .Paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
+    {{- $paginator = .Paginator.Pages.GroupByDate .Site.Params.yearFormat "asc" -}}
   {{- end -}}
   <div
     class="archives-outer-wrap"

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -14,7 +14,7 @@
   {{- else if eq $sort_config "weight-reverse" -}}
     {{- $paginator = .Paginator.Pages.ByWeight.Reverse -}}
   {{- else if eq $sort_config "time-reverse" -}}
-  {{- $paginator = .Paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
+    {{- $paginator = .Paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
   {{- end -}}
   <div
     class="archives-outer-wrap"

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -13,6 +13,8 @@
     {{- $paginator = .Paginator.Pages.ByWeight -}}
   {{- else if eq $sort_config "weight-reverse" -}}
     {{- $paginator = .Paginator.Pages.ByWeight.Reverse -}}
+  {{- else if eq $sort_config "time-reverse" -}}
+  {{- $paginator = .Paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
   {{- end -}}
   <div
     class="archives-outer-wrap"

--- a/layouts/archives/section.html
+++ b/layouts/archives/section.html
@@ -6,8 +6,7 @@
   {{- else if eq $sort_config "weight-reverse" -}}
     {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.ByWeight.Reverse -}}
   {{- else if eq $sort_config "time-reverse" -}}
-  {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.GroupByDate
-  .Site.Params.yearFormat "desc" -}}
+    {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
   {{- end -}}
   <div
     class="archives-outer-wrap"

--- a/layouts/archives/section.html
+++ b/layouts/archives/section.html
@@ -5,6 +5,9 @@
     {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.ByWeight -}}
   {{- else if eq $sort_config "weight-reverse" -}}
     {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.ByWeight.Reverse -}}
+  {{- else if eq $sort_config "time-reverse" -}}
+  {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.GroupByDate
+  .Site.Params.yearFormat "desc" -}}
   {{- end -}}
   <div
     class="archives-outer-wrap"

--- a/layouts/archives/section.html
+++ b/layouts/archives/section.html
@@ -6,7 +6,7 @@
   {{- else if eq $sort_config "weight-reverse" -}}
     {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.ByWeight.Reverse -}}
   {{- else if eq $sort_config "time-reverse" -}}
-    {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
+    {{- $paginator = (.Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections)).Pages.GroupByDate .Site.Params.yearFormat "asc" -}}
   {{- end -}}
   <div
     class="archives-outer-wrap"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,7 +51,7 @@
       {{- partial "post.html"  (dict "index" $k "ctx" . "page" $v ) -}}
     {{- end -}}
   {{- else if eq $sort_config "time-reverse" -}}
-    {{- range $k, $v := $paginator.Pages.ByDate.Reverse -}}
+    {{- range $k, $v := $paginator.Pages.ByDate-}}
       {{- partial "post.html" (dict "index" $k "ctx" . "page" $v ) -}}
     {{- end -}}
   {{- else -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,7 +51,7 @@
       {{- partial "post.html"  (dict "index" $k "ctx" . "page" $v ) -}}
     {{- end -}}
   {{- else if eq $sort_config "time-reverse" -}}
-    {{- range $k, $v := $paginator.Pages.ByDate-}}
+    {{- range $k, $v := $paginator.Pages.ByDate -}}
       {{- partial "post.html" (dict "index" $k "ctx" . "page" $v ) -}}
     {{- end -}}
   {{- else -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -50,6 +50,10 @@
     {{- range $k, $v := $paginator.Pages.ByWeight.Reverse -}}
       {{- partial "post.html"  (dict "index" $k "ctx" . "page" $v ) -}}
     {{- end -}}
+  {{- else if eq $sort_config "time-reverse" -}}
+  {{- range $k, $v := $paginator.Pages.ByDate.Reverse -}}
+  {{- partial "post.html" (dict "index" $k "ctx" . "page" $v ) -}}
+  {{- end -}}
   {{- else -}}
     {{- range $k, $v := $paginator.Pages -}}
       {{- partial "post.html"  (dict "index" $k "ctx" . "page" $v ) -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,9 +51,9 @@
       {{- partial "post.html"  (dict "index" $k "ctx" . "page" $v ) -}}
     {{- end -}}
   {{- else if eq $sort_config "time-reverse" -}}
-  {{- range $k, $v := $paginator.Pages.ByDate.Reverse -}}
-  {{- partial "post.html" (dict "index" $k "ctx" . "page" $v ) -}}
-  {{- end -}}
+    {{- range $k, $v := $paginator.Pages.ByDate.Reverse -}}
+      {{- partial "post.html" (dict "index" $k "ctx" . "page" $v ) -}}
+    {{- end -}}
   {{- else -}}
     {{- range $k, $v := $paginator.Pages -}}
       {{- partial "post.html"  (dict "index" $k "ctx" . "page" $v ) -}}

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -11,7 +11,7 @@
   {{- $sort_config = $ctx.Site.Params.sort_order.archive -}}
 {{- end -}}
 
-{{- if or (eq $sort_config "weight") (eq $sort_config "weight-reverse") (eq $sort_config "time-reverse") -}}
+{{- if or (eq $sort_config "weight") (eq $sort_config "weight-reverse") -}}
   <section class="archives-wrap" data-aos="{{ $ctx.Site.Params.animation.options.archive.section }}">
     <ul>
       {{- range $paginator -}}

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -11,7 +11,7 @@
   {{- $sort_config = $ctx.Site.Params.sort_order.archive -}}
 {{- end -}}
 
-{{- if or (eq $sort_config "weight") (eq $sort_config "weight-reverse") -}}
+{{- if or (eq $sort_config "weight") (eq $sort_config "weight-reverse") (eq $sort_config "time-reverse") -}}
   <section class="archives-wrap" data-aos="{{ $ctx.Site.Params.animation.options.archive.section }}">
     <ul>
       {{- range $paginator -}}

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -29,7 +29,7 @@
       >
       </a>
     {{- end -}}
-    {{- if and $page.Params.weight (eq $ctx.Site.Params.sort_order.home "time") -}}
+    {{- if and $page.Params.weight (or (eq $ctx.Site.Params.sort_order.home "time") (eq $ctx.Site.Params.sort_order.home "time-reverse") (not $ctx.Site.Params.sort_order.home)) -}}
       <div class="post-sticky">{{ i18n "sticky" }}</div>
     {{- end -}}
     <div


### PR DESCRIPTION
在已有的 `time` `weight` `weight_reverse` 基础上增加了 `time_reverse`

`time` 是新的在前，`time_reverse` 是旧的在前

原本想换一下 `time` 和 `time_reverse`， `time` 为旧的在前，`time_reverse` 为新的在前，但是没做出来
在这个分支 https://github.com/gongfuture/hugo-theme-reimu/tree/exchange_time_and_time_reverse