### PR TITLE
feat: 添加文章加密功能，支持密码保护和配置选项

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -792,6 +792,49 @@ home_categories:
       cover:
 ```
 
+#### Article Encryption
+
+Disabled by default. When enabled, you can encrypt articles you don't want to display publicly—users must enter a password to view the content.
+
+This feature relies on a third-party tool. Download it here: [reimuEncrypt-releases](https://github.com/2061360308/reimuEncrypt/releases)
+
+```yml
+########################################
+# Encrypted Articles
+########################################
+encrypt:
+  enable: true # Enable encryption
+  defaultPassword: "123456" # Default password
+```
+
+To correctly generate the `encrypt.json` configuration file, add the following to your `hugo.toml`:
+
+```toml
+# If you need RSS and Algolia, add "Algolia" and "RSS" to the list; otherwise, use the second option.
+[outputs]
+home = ["Algolia", "HTML", "RSS", "Encrypt"]
+
+[outputs]
+home = ["HTML", "Encrypt"]
+
+[outputFormats.Encrypt]
+mediaType = "application/json"
+baseName = "encrypt"
+isPlainText = true
+notAlternative = true
+```
+
+When writing articles, add the following to the front matter:
+
+```yaml
+encrypt:
+  enable: true                  # Enable encryption for this article
+  password: "secretpassword123" # Password
+  all: true                     # true to encrypt the entire article
+```
+
+> Note: Encryption only protects the generated static pages. The original Markdown files still contain the plaintext content and password. Please keep them safe—if using GitHub, consider making your repository private.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -815,6 +815,48 @@ home_categories:
       cover:
 ```
 
+#### 文章加密
+
+默认关闭，打开后可以将不想展示的文章进行加密，需要输入密码后才能查看
+
+依赖于第三方工具，此处下载 [reimuEncrypt-releases](https://github.com/2061360308/reimuEncrypt/releases)
+
+```yml
+########################################
+# Encrypted Articles
+########################################
+encrypt:
+  enable: true # 是否启用
+  defaultPassword: "123456" # 默认密码
+```
+
+为了能够正确生成配置文件`encrypt.json` 请在 `hugo.toml` 中添加如下配置
+
+```toml
+# 需要RSS以及Algolia，则添加"Algolia", "RSS"字段否则使用第二种
+[outputs]
+home = ["Algolia", "HTML", "RSS", "Encrypt"]
+
+[outputs]
+home = ["HTML", "Encrypt"]
+
+[outputFormats.Encrypt]
+mediaType = "application/json"
+baseName = "encrypt"
+isPlainText = true
+notAlternative = true
+```
+
+写作过程中front Matter配置
+```yaml
+encrypt:
+  enable: true                  # 文章开启加密
+  password: "secretpassword123" # 密码
+  all: true                     # true直接加密整篇文章
+```
+
+> 注意：加密只针对生成静态页面进行保护，原始Markdown等文件仍然包含明文密码需要自行妥善保管，如在使用Github时启用私有仓库
+
 </details>
 
 <details>

--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -672,3 +672,10 @@ internal_theme:
     --highlight-aqua: '#66cccc'
     --highlight-blue: '#54b6ff'
     --highlight-purple: '#dcbdfb'
+
+########################################
+# Encrypted Articles
+########################################
+encrypt:
+  enable: true # enable encrypted articles
+  defaultPassword: "123456" # default password for encrypted articles

--- a/layouts/_default/index.encrypt.json
+++ b/layouts/_default/index.encrypt.json
@@ -1,0 +1,70 @@
+{{- $encryptedArticles := slice -}}
+
+{{- range .Site.RegularPages -}}
+  {{- if and .Site.Params.encrypt.enable .Params.encrypt (eq .Params.encrypt.enable true) -}}
+    {{- $article := dict 
+      "title" .Title
+      "relPermalink" .RelPermalink
+      "uniqueID" .File.UniqueID
+    -}}
+    
+    {{- if and .Params.encrypt.password (ne .Params.encrypt.password "") -}}
+      {{- $article = merge $article (dict "password" .Params.encrypt.password) -}}
+    {{- end -}}
+
+    {{- if isset .Params.encrypt "all" -}}
+      {{- $article = merge $article (dict "all" .Params.encrypt.all) -}}
+    {{- else -}}
+      {{- $article = merge $article (dict "all" false) -}}
+    {{- end -}}
+    
+    {{- $encryptedArticles = $encryptedArticles | append $article -}}
+  {{- end -}}
+{{- end -}}
+
+{
+  "generatedAt": "{{ now.Format "2006-01-02T15:04:05Z07:00" }}",
+  "totalCount": {{ len $encryptedArticles }},
+  "defaultPassword": {{ .Site.Params.encrypt.defaultPassword | jsonify }},
+  {{- /* 全篇文章加密配置  */ -}}
+  "encrypted-all": [
+    {
+      "name": "article",        {{- /* 名称 */ -}}
+      "selector": "article",    {{- /* 元素CSS选择器 */ -}}
+      "selectAll": false,       {{- /* 是否查询并操作所有匹配的子节点 */ -}}
+      "replace": {
+        "innerHTML": false,     {{- /* true保留标签替换内部内容，false替换整个标签元素 */ -}}
+        "content": ""           {{- /* 替换内容 */ -}}
+      },
+      "password": ""            {{- /* 如果需要从元素获取密码，提供CSS选择器（会从上级selector选中元素中查找） */ -}}
+    },
+    {
+      "name": "sidebar",
+      "selector": "#TableOfContents",
+      "selectAll": false,
+      "replace": {
+        "innerHTML": false,
+        "content": ""
+      }
+    }
+  ],
+  {{- /* 文章局部加密配置  */ -}}
+  "encrypted-partial": [],
+  {{- /* 加密文章列表  */ -}}
+  "articles": [
+    {{- range $index, $article := $encryptedArticles -}}
+      {{- if gt $index 0 -}},{{- end -}}
+      {
+        "title": {{ $article.title | jsonify }},
+        "filePath": {{ (print (replace $article.relPermalink "/" "" 1) "index.html") | jsonify }},
+        "uniqueID": {{ $article.uniqueID | jsonify }}
+        {{- if isset $article "password" -}}
+        , "password": {{ $article.password | jsonify }}
+        {{- end -}}
+        {{- if isset $article "password" -}}
+        , "all": {{ $article.all | jsonify }}
+        {{- end -}}
+      }
+    {{- end -}}
+  ]
+}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -122,3 +122,6 @@
   {{- end -}}
 </article>
 {{- partial "comment.html" . -}}
+{{- if in .Site.Params.mainSections .Type -}}
+  {{- partial "post/encrypt.html" . -}}
+{{- end -}}

--- a/layouts/partials/post/encrypt.html
+++ b/layouts/partials/post/encrypt.html
@@ -1,0 +1,155 @@
+{{- if and .Site.Params.encrypt.enable (isset .Params "encrypt") .Params.encrypt.enable -}}
+{{- if .Params.encrypt.all -}}
+<style>
+    .encrypted-content {
+        background: var(--color-wrap);
+        border-radius: 10px;
+        display: flow-root;
+        transition: 0.3s;
+        padding: 20px;
+    }
+
+    .encrypted-header {
+        background: var(--red-5-5);
+        border-left: 6px var(--red-4) solid;
+        margin: 1.2em 0;
+        border-radius: 10px;
+        transition: 0.3s;
+        padding: 1px 10px;
+        box-shadow: var(--shadow-meta);
+        padding: 15px 5px;
+        text-align: center;
+    }
+
+    #encrypt-password {
+        padding: 10px 16px;
+        border: 2px solid var(--color-border);
+        border-radius: 6px;
+        font-size: 1em;
+        outline: none;
+        transition: border 0.2s;
+        background-color: var(--color-background);
+        color: var(--color-default);
+    }
+
+    #encrypt-password:focus {
+        border-color: var(--red-1);
+    }
+
+    #encrypt-button {
+        padding: 2px 18px;
+        border: 10px var(--color-red-3-shadow) double;
+        color: var(--red-2);
+        font-size: 14px;
+        background-color: var(--color-background);
+        margin-bottom: 30px;
+    }
+
+    #encrypt-button:hover {
+        border-color: var(--red-1);
+        color: var(--red-1);
+        font-weight: bolder;
+    }
+
+    .sliderbar-encrypt-mask {
+        width: 100%;
+        height: 220px;
+        background: var(--red-5-5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 24px;
+        border-radius: 10px;
+        backdrop-filter: blur(8px);
+        /* 磨砂模糊效果 */
+        -webkit-backdrop-filter: blur(8px);
+        /* 兼容Safari */
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+    }
+</style>
+<script>
+    let mainElement;
+    let sidebarElement;
+    async function encryptPassword() {
+        const password = document.getElementById("encrypt-password").value;
+        if (!password) {
+            alert("请输入密码");
+            return;
+        }
+
+        let article = __ENCRYPT_DATA__.article;
+        let sidebar = __ENCRYPT_DATA__.sidebar;
+
+        console.log(article)
+        console.log(sidebar)
+        console.log(password)
+
+        // 解密article内容
+        if (!article || !password) {
+            throw new Error('请填写加密数据和密码');
+        }
+
+        let decryptedArticle = await encrypt(article, password);
+
+        console.log(decryptedArticle)
+
+        // 显示解密结果
+        mainElement.insertAdjacentHTML("afterbegin", decryptedArticle);
+        document.querySelector('.encrypted-content').remove();
+
+        // 解密sidebar内容
+        if (!sidebar || !password) {
+            throw new Error('请填写加密数据和密码');
+        }
+
+        let decryptedSidebar = await encrypt(sidebar, password);
+
+        console.log(decryptedSidebar)
+
+        // 显示解密结果
+        document.querySelector(".toc-div-class").insertAdjacentHTML("afterbegin", decryptedSidebar);
+        document.querySelector('.sliderbar-encrypt-mask').remove();
+
+        // Todo 错误密码提示
+        // Todo 保存密码到浏览器缓存
+    }
+    document.addEventListener("DOMContentLoaded", function () {
+        // Todo 处理缓存密码
+        
+        // 添加显示加密部分占位元素
+        let enctyptedArcitleElement = `
+        <div class="encrypted-content aos-init aos-animate">
+            <div class="encrypted-header">
+                🔐 内容已隐藏，输入密码后查看
+            </div>
+            <div style="text-align:center; margin-top:18px;">
+                <input type="password" id="encrypt-password" placeholder="请输入密码" />
+                <button type="button" id="encrypt-button" onclick="encryptPassword()">解锁</button>
+            </div>
+        </div>
+        `;
+        let enctyptedSidebarElement = `
+        <div class="sliderbar-encrypt-mask">
+            🔐
+        </div>
+        `;
+        mainElement = document.querySelector("#main");
+        if (mainElement) {
+            mainElement.insertAdjacentHTML("afterbegin", enctyptedArcitleElement);
+        }
+        let sidebarElements = document.querySelectorAll(".toc-div-class");
+        sldebarElement = sidebarElements[0];
+        let sidebarElementMobie = sidebarElements[1];
+
+        if (sldebarElement) {
+            sldebarElement.insertAdjacentHTML("afterbegin", enctyptedSidebarElement);
+        }
+    });
+</script>
+{{- else -}}
+<script>
+    // Todo 文章局部内容加密
+    console.log("Hello, Partial");
+</script>
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
别人的项目还得重头看，为了方便今天再次改了之前的项目，然后简单补上了这个新功能的提交

缺陷：
- 没有支持文章局部内容加密
- 缺少密码缓存
- 输入错误密码没有显示提示内容
- 移动端侧边栏目录容器没有处理

> 按照之前思路简化开始的流程，另外将解密相关方法也自动写入html，现在可以直接使用