### PR TITLE
feat: 单文章 outdated 支持 False

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -22,7 +22,7 @@
             {{ replace $msg "{time}" ($.Lastmod.Format $.Site.Params.dateFormat) }}
           </p>
         </blockquote>
-      {{- else if .Site.Params.outdate.enable -}}
+      {{- else if and (not (isset .Params "outdated")) .Site.Params.outdate.enable -}}
         <blockquote
           class="alert-blockquote warning"
           id="outdate-blockquote"


### PR DESCRIPTION
非常小的一个改动

原本单文章 outdated 只支持为 true 的场景
现在增加了一个为 false 的场景

文章 front matter `outdated` 字段为 `false` 时，无论什么情况都不显示过期警告