### PR TITLE
feat: add typing animation support for subtitle

### DIFF
--- a/data/vendor.yml
+++ b/data/vendor.yml
@@ -98,6 +98,9 @@ js:
   material_theme:
     src: webcache|material-theme@1.0.0/dist/material-theme.umd.js
     integrity: sha384-vLev0II0HKFaxkcm+/7kX5IGwVFBASkGchU311wmU/veIj2bB0UcBkQbW6yw2asK
+  typed:
+    src: cdn_jsdelivr_npm|typed.js@2.1.0/dist/typed.umd.js
+    integrity: sha384-cMrTlShXEGSdSFA359p+3aVUxK/R+0TAfbRZMcTlAn8yqzxEDj05QsS65nTFMMj4
 css:
   photoswipe:
     src: webcache|photoswipe@5.4.4/dist/photoswipe.css

--- a/layouts/partials/afterFooter.html
+++ b/layouts/partials/afterFooter.html
@@ -12,6 +12,23 @@
 
 {{- partial "helpers/ts.html" (dict "source" "js/main.ts" "ctx" .) -}}
 
+{{- if and .IsHome (reflect.IsMap .Site.Params.subtitle) .Site.Params.subtitle.typing.enable -}}
+<script>
+  function initSubtitleTyping() {
+    const subtitleElement = document.querySelector('#subtitle span');
+    if (!subtitleElement || !window.Typed || !window.subtitleTypingConfig) {
+      return;
+    }
+    new Typed('#subtitle span', window.subtitleTypingConfig);
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initSubtitleTyping);
+  } else {
+    initSubtitleTyping();
+  }
+</script>
+{{- end -}}
+
 {{- if $params.animation.enable -}}
   {{- partial "helpers/ts.html" (dict "source" "js/aos.ts" "ctx" .) -}}
   <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -146,3 +146,29 @@
 {{- if .Site.Params.player.aplayer.enable -}}
   {{- partial "helpers/css.html" (dict "raw" $css.aplayer "src" (index (partial "helpers/vendorCdn.html" (dict "item" $css.aplayer "ctx" $site)) 0) "integrity" (index (partial "helpers/vendorCdnIntegrity.html" (dict "item" $css.aplayer)) 0)) -}}
 {{- end -}}
+
+<!-- Typed.js for subtitle typing effect -->
+{{- if and .IsHome (reflect.IsMap .Site.Params.subtitle) .Site.Params.subtitle.typing.enable -}}
+{{- partial "helpers/js.html" (dict "raw" $js.typed "src" (index (partial "helpers/vendorCdn.html" (dict "item" $js.typed "ctx" $site)) 0) "integrity" (index (partial "helpers/vendorCdnIntegrity.html" (dict "item" $js.typed)) 0)) -}}
+<script>
+  window.subtitleTypingConfig = {
+    strings: [
+      {{- range $index, $string := .Site.Params.subtitle.typing.strings -}}
+        {{- if $index -}},{{- end -}}
+        "{{ $string }}"
+      {{- end -}}
+    ],
+    typeSpeed: {{ .Site.Params.subtitle.typing.typeSpeed | default 100 }},
+    backSpeed: {{ .Site.Params.subtitle.typing.backSpeed | default 50 }},
+    backDelay: {{ .Site.Params.subtitle.typing.backDelay | default 2000 }},
+    startDelay: {{ .Site.Params.subtitle.typing.startDelay | default 300 }},
+    loop: {{ .Site.Params.subtitle.typing.loop | default true }},
+    shuffle: {{ .Site.Params.subtitle.typing.shuffle | default false }},
+    showCursor: {{ .Site.Params.subtitle.typing.showCursor | default false }},
+    {{- if .Site.Params.subtitle.typing.cursorChar -}}
+    cursorChar: "{{ .Site.Params.subtitle.typing.cursorChar }}",
+    {{- end -}}
+    smartBackspace: {{ .Site.Params.subtitle.typing.smartBackspace | default true }}
+  };
+</script>
+{{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -207,8 +207,15 @@
         </h2>
       {{- else -}}
         {{- $subtitle := "" -}}
+        {{- $useTyping := false -}}
         {{- if .IsHome -}}
-          {{- $subtitle = .Site.Params.subtitle | default .Site.Params.subtitle -}}
+          {{- if and (reflect.IsMap .Site.Params.subtitle) .Site.Params.subtitle.typing.enable -}}
+            {{- $useTyping = true -}}
+          {{- else if and (reflect.IsMap .Site.Params.subtitle) .Site.Params.subtitle.text -}}
+            {{- $subtitle = .Site.Params.subtitle.text -}}
+          {{- else if .Site.Params.subtitle -}}
+            {{- $subtitle = .Site.Params.subtitle -}}
+          {{- end -}}
         {{- else if and (eq .Type "categories") (not (eq .Title "Categories")) -}}
           {{- $subtitle = .Title -}}
         {{- else if and (eq .Type "tags") (not (eq .Title "Tags")) -}}
@@ -219,7 +226,9 @@
           {{- end -}}
         {{- end -}}
         <h2 id="subtitle-wrap" data-aos="{{ .Site.Params.animation.options.header.subTitle }}">
-          {{- if $subtitle -}}
+          {{- if $useTyping -}}
+            <span id="subtitle"><span></span></span>
+          {{- else if $subtitle -}}
             <span id="subtitle">{{ $subtitle }}</span>
           {{- end -}}
         </h2>


### PR DESCRIPTION
添加typed.js实现副标题打字机效果，并支持多语句，兼容旧subtitle配置。
```yaml
subtitle:
  typing:
    enable: true
    strings:
      - 语句1
      - 语句2
    typeSpeed: 100              # 打字速度（毫秒/字符）
    backSpeed: 50               # 删除速度
    backDelay: 2000             # 打完一句话后，等待时间
    startDelay: 300             # 页面加载后，等待时间
    loop: true                  # 循环播放
    shuffle: true              # 随机输出
    showCursor: true            # 显示闪烁的光标字符
    cursorChar: "|"             # 光标字符
    smartBackspace: false       # 智能退格，只删除不同的部分

  text: "少女祈祷中..."        # 当enable = false 时使用