### PR TITLE
feat: 区分文章背景图，文章卡片封面图

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -79,6 +79,8 @@
   {{- $ogImage := "" -}}
   {{- if and .Params.cover (not (strings.HasPrefix .Params.cover "rgb")) -}}
     {{- $ogImage = .Params.cover | absURL -}}
+  {{- else if and .Params.banner (not (strings.HasPrefix .Params.banner "rgb")) -}}
+    {{- $ogImage = .Params.banner | absURL -}}
   {{- else -}}
     {{- $ogImage = .Site.Params.banner | absURL -}}
   {{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -106,13 +106,14 @@
   {{- end -}}
 </div>
 <header id="header" aria-label="Site header">
-  {{- if and .Params.cover (strings.HasPrefix .Params.cover "rgb") -}}
+  {{- $headerImage := .Params.banner | default .Params.cover -}}
+  {{- if and $headerImage (strings.HasPrefix $headerImage "rgb") -}}
     <picture></picture>
-    <img style="position: absolute;top: 0;left: 0;width: 100%;height: 180%;z-index: -2;display: block;background: {{ .Params.cover | safeCSS }};mask: linear-gradient(to top, transparent, #fff 50%);"></img>
-  {{- else if .Params.cover -}}
+    <img style="position: absolute;top: 0;left: 0;width: 100%;height: 180%;z-index: -2;display: block;background: {{ $headerImage | safeCSS }};mask: linear-gradient(to top, transparent, #fff 50%);"></img>
+  {{- else if $headerImage -}}
     <picture></picture>
-    <img {{ if .Site.Params.material_theme.enable }}crossorigin="anonymous"{{ end }} fetchpriority="high" src="{{ .Params.cover | relURL }}" alt="{{ .Title }}">
-  {{- else if eq .Params.cover false -}}
+    <img {{ if .Site.Params.material_theme.enable }}crossorigin="anonymous"{{ end }} fetchpriority="high" src="{{ $headerImage | relURL }}" alt="{{ .Title }}">
+  {{- else if or (eq .Params.banner false) (eq .Params.cover false) -}}
     <picture></picture>
     <img style="visibility:hidden"></img>
   {{- else -}}


### PR DESCRIPTION
Front-matter 添加banner，使用cover和banner分别设置文章卡片封面和文章背景图，并向后兼容

cover 用于列表卡片封面和社交分享
banner 用于文章头部背景图

1. 只设置 cover
cover: "/images/1.webp"
文章背景图： 1webp
文章卡片封面：1.webp
社交分享图：1.webp

2. 只设置 banner
banner: "/images/2.webp"
文章背景图：2.webp
文章卡片封面：使用covers.yml定义的
社交分享图：2webp

3. 同时设置 cover 和 banner
cover: "/images/1.webp"
banner: "/images/2.webp"
文章背景图：2.webp
文章卡片封面：1.webp
社交分享图：1.webp
