### PR TITLE
feat: add paragraph anchor support for article content

### DIFF
--- a/assets/css/partials/article.scss
+++ b/assets/css/partials/article.scss
@@ -119,8 +119,21 @@
   }
 
   // Paragraph anchor — matches header-anchor style
-  p:has(.paragraph-anchor) {
-    position: relative;
+  // 修复 #5：position: relative 覆盖所有可能包含锚点图标的块级元素，
+  // 而不是只在 p:has(...) 时才设置；hover 效果也同理。
+  p,
+  li,
+  dd,
+  dt,
+  td,
+  th,
+  blockquote,
+  details,
+  figure,
+  figcaption {
+    &:has(.paragraph-anchor) {
+      position: relative;
+    }
   }
 
   .paragraph-anchor {
@@ -154,7 +167,17 @@
     }
   }
 
-  p:hover > .paragraph-anchor {
+  // 修复 #5：hover 效果覆盖所有包含锚点图标的块级元素，而不仅限于 p
+  p:hover > .paragraph-anchor,
+  li:hover > .paragraph-anchor,
+  dd:hover > .paragraph-anchor,
+  dt:hover > .paragraph-anchor,
+  td:hover > .paragraph-anchor,
+  th:hover > .paragraph-anchor,
+  blockquote:hover > .paragraph-anchor,
+  details:hover > .paragraph-anchor,
+  figure:hover > .paragraph-anchor,
+  figcaption:hover > .paragraph-anchor {
     opacity: 0.5;
   }
 

--- a/assets/css/partials/article.scss
+++ b/assets/css/partials/article.scss
@@ -118,6 +118,46 @@
     margin-bottom: 40px;
   }
 
+  // Paragraph anchor — matches header-anchor style
+  p:has(.paragraph-anchor) {
+    position: relative;
+  }
+
+  .paragraph-anchor {
+    opacity: 0;
+    // 隐藏浏览器或全局样式为 <a> 添加的 ::after 伪元素
+    &::after {
+      display: none;
+    }
+    @if $icon_font {
+      font-family: $font-icon;
+    } @else {
+      font-family: var(--font-icon);
+    }
+    font-size: 0.7em;
+    vertical-align: middle;
+    text-decoration: none !important;
+    margin-left: 4px;
+    transition: 0.3s;
+
+    &:hover {
+      opacity: 0.8;
+      text-decoration: none !important;
+    }
+
+    &::before {
+      @if $icon_font {
+        content: "\e62b";
+      } @else {
+        content: "\f292";
+      }
+    }
+  }
+
+  p:hover > .paragraph-anchor {
+    opacity: 0.5;
+  }
+
   a {
     color: var(--color-link);
     text-decoration: none;

--- a/assets/js/anchor.ts
+++ b/assets/js/anchor.ts
@@ -26,16 +26,19 @@
   // anchor.explicit.marker  - 锚点占位符前缀，默认 "{#anchor-"
   //                         完整模式 = marker + id + "}"
   //                         例如 marker = "{#anchor-" → 匹配 "{#anchor-ref1}"
+  // anchor.explicit.prefix  - 自动锚点 id 前缀，默认 "anchor-"
+  //                         仅在显式锚点时使用，auto 锚点不受此影响
   // anchor.auto.enable      - 是否启用自动锚点，默认 false
   // anchor.auto.length      - 自动锚点 id 最大长度，默认 60
   const anchorConfig = (window as unknown as { siteConfig: { anchor?: {
-    explicit?: { enable?: boolean; marker?: string };
+    explicit?: { enable?: boolean; marker?: string; prefix?: string };
     auto?: { enable?: boolean; length?: number };
   }}}).siteConfig?.anchor ?? {};
   const enableExplicit = anchorConfig.explicit?.enable ?? false;
   const enableAuto = anchorConfig.auto?.enable ?? false;
   const autoLength = Math.max(1, Math.min(anchorConfig.auto?.length ?? 60, 200));
   const marker = anchorConfig.explicit?.marker ?? "{#anchor-";
+  const explicitPrefix = anchorConfig.explicit?.prefix ?? "anchor-";
 
   // 构造完整的锚点正则表达式
   // 匹配 {marker-xxx}，如 marker = "{#anchor-" → 匹配 "{#anchor-ref1}"
@@ -45,7 +48,19 @@
     "g"
   );
 
-  const articleEntry = _$(".article-entry");
+  // ---------------------------------------------------------------
+  // 定位文章正文容器（修复 #1：防止锚点注入到摘要/blockquote 等非正文容器）
+  //
+  // 优先查找带 itemprop="articleBody" 的 .e-content.article-entry
+  //（summary/blockquote 模式中正文有此属性，摘要没有）。
+  // 若未命中则降级为包含 .Content 的 .article-entry。
+  // ---------------------------------------------------------------
+  const articleEntry = (
+    document.querySelector(".e-content.article-entry[itemprop=\"articleBody\"]") ??
+    document.querySelector(".e-content .article-entry:has(.Content)") ??
+    document.querySelector(".article-entry:has(.Content)") ??
+    document.querySelector(".article-entry")
+  );
   if (!articleEntry) return;
 
   // 支持显式锚点语法的块级元素类型列表
@@ -72,39 +87,76 @@
   if (enableExplicit) {
     blockSelectors.forEach((selector) => {
       articleEntry.querySelectorAll<HTMLElement>(selector).forEach((el) => {
-        // 限定在 .article-entry 内，避免误匹配页眉、页脚、导航中的元素
+        // 限定在 articleEntry 内，避免误匹配页眉、页脚、导航中的元素
         if (!el.closest(".article-entry") || el.closest("header, footer, nav")) return;
 
         const html = el.innerHTML;
-        let match: RegExpExecArray | null;
-        // 重置正则状态，避免 lastIndex 残留导致匹配遗漏
+        anchorPattern.lastIndex = 0;
+
+        // 先快速检测：若无匹配则直接跳过，完全避免 innerHTML round-trip
+        if (!anchorPattern.test(html)) return;
+        // 重置 lastIndex（test 会推进到末尾）
         anchorPattern.lastIndex = 0;
 
         // 遍历所有匹配的 {marker}xxx}（一个元素中可能出现多个）
+        let match: RegExpExecArray | null;
+        let hasExplicitAnchor = false;
         while ((match = anchorPattern.exec(html)) !== null) {
           const anchorId = match[1].trim();
           if (!anchorId) continue; // 忽略空 id
 
-          // 若元素尚未有 id，则注入 id="anchor-{xxx}"
-          // 若已有 id（如手动指定或前面已注入），保留原 id 不覆盖
-          if (!el.id) {
-            el.id = `anchor-${anchorId}`;
+          const targetId = `${explicitPrefix}${anchorId}`;
+
+          // 若元素已有 id，进行冲突检测
+          if (el.id && el.id !== targetId) {
+            console.warn(
+              `[anchor] id="${el.id}" conflicts with explicit marker "${match[0]}" ` +
+              `→ icon will link to "${el.id}", not "${targetId}"`,
+            );
+            continue; // 以原有 id 为准，不覆盖
           }
 
-          // 追加锚点图标，仅在尚无锚点图标时添加
-          // （同一元素内多个 {marker}xxx} 只加一个图标）
-          if (!el.querySelector(".paragraph-anchor")) {
-            const anchor = document.createElement("a");
-            anchor.className = "paragraph-anchor";
-            anchor.href = `#${el.id}`;
-            anchor.setAttribute("aria-label", "anchor");
-            el.appendChild(anchor);
+          // 注入 id（已有 id === targetId 时跳过）
+          if (!el.id) {
+            el.id = targetId;
           }
+
+          hasExplicitAnchor = true;
         }
 
-        // 将所有 {marker}xxx} 文本占位符从 DOM 中移除，
-        // 不影响元素内其他内容的渲染（如链接、图片等）
-        el.innerHTML = el.innerHTML.replace(anchorPattern, "");
+        // 仅在存在显式锚点时才添加图标（同一元素多个 marker 只加一个）
+        if (hasExplicitAnchor && !el.querySelector(".paragraph-anchor")) {
+          const anchor = document.createElement("a");
+          anchor.className = "paragraph-anchor";
+          anchor.href = `#${el.id}`;
+          anchor.setAttribute("aria-label", "anchor");
+          el.appendChild(anchor);
+        }
+
+        // ---------------------------------------------------------------
+        // 修复 #2：使用 TextNode 遍历替代无条件 innerHTML replace，
+        // 避免 HTML 重解析导致子节点状态（details open、事件监听器）丢失。
+        // ---------------------------------------------------------------
+        const walker = document.createTreeWalker(
+          el,
+          NodeFilter.SHOW_TEXT,
+          null,
+        );
+        const textNodes: Text[] = [];
+        let textNode: Text | null;
+        while ((textNode = walker.nextNode() as Text | null)) {
+          textNodes.push(textNode);
+        }
+        anchorPattern.lastIndex = 0;
+        for (const node of textNodes) {
+          const original = node.textContent ?? "";
+          const replaced = original.replace(anchorPattern, "");
+          if (replaced !== original) {
+            node.textContent = replaced;
+            // 只在第一个匹配节点处重置 lastIndex，后续节点重新遍历
+            anchorPattern.lastIndex = 0;
+          }
+        }
       });
     });
   }

--- a/assets/js/anchor.ts
+++ b/assets/js/anchor.ts
@@ -1,0 +1,179 @@
+/**
+ * 段落锚点功能
+ *
+ * 支持两种锚点注入方式：
+ *
+ * 1. 显式锚点（需 params.yml 中 anchor.explicit = true）：
+ *    用户在 Markdown 中使用 {marker}xxx} 语法（如 {#anchor-ref1}），
+ *    将锚点 id 绑定到任意块级元素（<p>、<li>、<blockquote> 等）。
+ *    例如：- [参考文献1](url) {#anchor-ref1}
+ *    渲染后：<li id="anchor-ref1"><a href="url">参考文献1</a>（+锚点图标）</li>
+ *
+ * 2. 自动锚点（需 params.yml 中 anchor.auto = true）：
+ *    对于文章中的直接子段落（.article-entry > p），
+ *    若未手动指定锚点，则从段落文本内容自动生成 id，
+ *    格式为将文本转为小写、中文/非字母数字字符替换为连字符、
+ *    截断至 anchor.auto_length 指定的长度（默认 60）。
+ *    例如：「Hello World！你好」 → id="hello-world"
+ *
+ * 3. URL Hash 滚动：页面加载时检测 URL 中的 hash，
+ *    若存在对应 id 的元素则平滑滚动到视口中央。
+ */
+
+(() => {
+  // 从主题配置中读取锚点相关参数
+  // anchor.explicit.enable  - 是否启用显式锚点语法，默认 false
+  // anchor.explicit.marker  - 锚点占位符前缀，默认 "{#anchor-"
+  //                         完整模式 = marker + id + "}"
+  //                         例如 marker = "{#anchor-" → 匹配 "{#anchor-ref1}"
+  // anchor.auto.enable      - 是否启用自动锚点，默认 false
+  // anchor.auto.length      - 自动锚点 id 最大长度，默认 60
+  const anchorConfig = (window as unknown as { siteConfig: { anchor?: {
+    explicit?: { enable?: boolean; marker?: string };
+    auto?: { enable?: boolean; length?: number };
+  }}}).siteConfig?.anchor ?? {};
+  const enableExplicit = anchorConfig.explicit?.enable ?? false;
+  const enableAuto = anchorConfig.auto?.enable ?? false;
+  const autoLength = Math.max(1, Math.min(anchorConfig.auto?.length ?? 60, 200));
+  const marker = anchorConfig.explicit?.marker ?? "{#anchor-";
+
+  // 构造完整的锚点正则表达式
+  // 匹配 {marker-xxx}，如 marker = "{#anchor-" → 匹配 "{#anchor-ref1}"
+  // 捕获组 [1] 为锚点 id（xxx 部分，不含大括号）
+  const anchorPattern = new RegExp(
+    marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "([^}]+)\\}",
+    "g"
+  );
+
+  const articleEntry = _$(".article-entry");
+  if (!articleEntry) return;
+
+  // 支持显式锚点语法的块级元素类型列表
+  // 覆盖 Markdown 渲染后常见的块级容器：
+  //   p        - 段落
+  //   li       - 列表项（用于参考文献、引用列表等）
+  //   dd/dt    - 定义列表项
+  //   td/th    - 表格单元格
+  //   blockquote - 引用块
+  //   details  - 可折叠 details 元素
+  //   figure   - 图片/代码块等 figure 容器
+  //   figcaption - figure 的标题
+  const blockSelectors = [
+    "p", "li", "dd", "dt", "td", "th",
+    "blockquote", "details", "figure", "figcaption",
+  ];
+
+  // ---------------------------------------------------------------
+  // 第 1 部分：处理显式锚点语法（仅在 anchor.explicit = true 时启用）
+  //
+  // 遍历所有目标块级元素，检测其中是否包含 {marker}xxx} 文本。
+  // 若存在：注入 id、添加锚点图标、移除文本占位符。
+  // ---------------------------------------------------------------
+  if (enableExplicit) {
+    blockSelectors.forEach((selector) => {
+      articleEntry.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+        // 限定在 .article-entry 内，避免误匹配页眉、页脚、导航中的元素
+        if (!el.closest(".article-entry") || el.closest("header, footer, nav")) return;
+
+        const html = el.innerHTML;
+        let match: RegExpExecArray | null;
+        // 重置正则状态，避免 lastIndex 残留导致匹配遗漏
+        anchorPattern.lastIndex = 0;
+
+        // 遍历所有匹配的 {marker}xxx}（一个元素中可能出现多个）
+        while ((match = anchorPattern.exec(html)) !== null) {
+          const anchorId = match[1].trim();
+          if (!anchorId) continue; // 忽略空 id
+
+          // 若元素尚未有 id，则注入 id="anchor-{xxx}"
+          // 若已有 id（如手动指定或前面已注入），保留原 id 不覆盖
+          if (!el.id) {
+            el.id = `anchor-${anchorId}`;
+          }
+
+          // 追加锚点图标，仅在尚无锚点图标时添加
+          // （同一元素内多个 {marker}xxx} 只加一个图标）
+          if (!el.querySelector(".paragraph-anchor")) {
+            const anchor = document.createElement("a");
+            anchor.className = "paragraph-anchor";
+            anchor.href = `#${el.id}`;
+            anchor.setAttribute("aria-label", "anchor");
+            el.appendChild(anchor);
+          }
+        }
+
+        // 将所有 {marker}xxx} 文本占位符从 DOM 中移除，
+        // 不影响元素内其他内容的渲染（如链接、图片等）
+        el.innerHTML = el.innerHTML.replace(anchorPattern, "");
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------
+  // 第 2 部分：为直接子段落自动生成 id + 锚点图标
+  // （仅在 anchor.auto = true 时启用）
+  //
+  // 仅处理 .article-entry 的直接子 <p> 元素（:scope > p），
+  // 且该段落此前未被显式锚点注入过 id。
+  // id 由段落文本内容派生：全小写、特殊字符替换、长度截断。
+  // ---------------------------------------------------------------
+  if (enableAuto) {
+    const paragraphs = Array.from(
+      articleEntry.querySelectorAll(":scope > p"),
+    ) as HTMLParagraphElement[];
+
+    paragraphs.forEach((p) => {
+      // 已有 id（手动指定或步骤 1 已注入）则跳过
+      if (p.id) return;
+
+      // 若段落文本本身包含 {marker}xxx}，说明这是纯标记段落，跳过自动生成
+      const html = p.innerHTML;
+      anchorPattern.lastIndex = 0;
+      if (anchorPattern.test(html)) return;
+
+      const text = p.textContent?.trim() ?? "";
+      if (!text) return; // 空段落不生成锚点
+
+      // 从段落文本派生 id：
+      // 1. 转小写
+      // 2. 所有非字母数字、中文字符替换为连字符 -
+      // 3. 去除首尾连字符
+      // 4. 截断至 autoLength 字符（防止超长 id）
+      // 例如：「Hello World！你好」 → "hello-world"
+      const id = text
+        .toLowerCase()
+        .replace(/[^a-z0-9\u4e00-\u9fa5]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, autoLength);
+
+      if (!id) return;
+
+      p.id = id;
+
+      // 追加锚点图标，与步骤 1 相同的逻辑
+      const anchor = document.createElement("a");
+      anchor.className = "paragraph-anchor";
+      anchor.href = `#${id}`;
+      anchor.setAttribute("aria-label", "anchor");
+      p.appendChild(anchor);
+    });
+  }
+
+  // ---------------------------------------------------------------
+  // 第 3 部分：页面加载时平滑滚动到 URL hash 对应元素
+  //
+  // 读取页面加载时的 URL hash（如 #anchor-ref1），
+  // 若存在对应 id 的元素则使用 smooth 行为滚动至视口中央。
+  // decodeURIComponent 处理含中文或特殊字符的 hash。
+  // ---------------------------------------------------------------
+  const hash = window.location.hash;
+  if (hash) {
+    const target = document.getElementById(decodeURIComponent(hash.slice(1)));
+    if (target) {
+      // requestAnimationFrame 确保 DOM 完全就绪后再执行滚动
+      requestAnimationFrame(() => {
+        target.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
+    }
+  }
+})();

--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -90,6 +90,23 @@ open_graph:
 # Content
 excerpt_link: Read More
 
+# Paragraph anchor
+# 为文章正文中的段落和列表项注入可跳转的锚点链接
+# 使用方式：在 Markdown 中写 {#anchor-xxx}，对应元素会获得 id="anchor-xxx" 并显示锚点图标
+anchor:
+  # 显式锚点
+  explicit: 
+    # 是否启用显式锚点：解析 Markdown 中 {#anchor-xxx} 语法
+    enable: true
+    # 锚点占位符：显式锚点匹配的模式（无需修改，除非与正文内容冲突）
+    marker: "{#anchor-"
+  # 自动锚点
+  auto:
+  # 是否启用自动锚点：为直接子段落自动生成 id（从文本内容派生）
+    enable: false
+    # 自动锚点的 id 最大长度，超出则截断（仅 auto=true 时生效）
+    length: 60
+
 # Footer copyright
 # Inject code snippet right in the footer copyright
 # Make sure your code snippet is safeHTML

--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -96,13 +96,15 @@ excerpt_link: Read More
 anchor:
   # 显式锚点
   explicit: 
-    # 是否启用显式锚点：解析 Markdown 中 {#anchor-xxx} 语法
-    enable: true
+    # 是否启用显式锚点：解析 Markdown 中 {#anchor-xxx} 语法（默认 false）
+    enable: false
     # 锚点占位符：显式锚点匹配的模式（无需修改，除非与正文内容冲突）
     marker: "{#anchor-"
+    # 自动锚点 id 前缀，生成的 id = prefix + marker 中的 xxx 部分（默认 "anchor-"）
+    prefix: "anchor-"
   # 自动锚点
   auto:
-  # 是否启用自动锚点：为直接子段落自动生成 id（从文本内容派生）
+    # 是否启用自动锚点：为直接子段落自动生成 id（从文本内容派生，默认 false）
     enable: false
     # 自动锚点的 id 最大长度，超出则截断（仅 auto=true 时生效）
     length: 60

--- a/layouts/partials/afterFooter.html
+++ b/layouts/partials/afterFooter.html
@@ -217,6 +217,7 @@
     {{- end -}}
     {{- if not .IsHome -}}
       {{- partial "helpers/ts.html" (dict "source" "js/insert_highlight.ts" "pjax" true "ctx" .) -}}
+      {{- partial "helpers/ts.html" (dict "source" "js/anchor.ts" "pjax" true "ctx" .) -}}
       {{- partial "helpers/ts.html" (dict "source" "js/tabs.ts" "pjax" true "ctx" . "defer" true) -}}
       {{- $photoswipe_lightbox := index (partial "helpers/vendorCdn.html" (dict "item" $js.photoswipe_lightbox "ctx" $site)) 0 -}}
       {{- $photoswipe_lightbox_integrity := index (partial "helpers/vendorCdnIntegrity.html" (dict "item" $js.photoswipe_lightbox)) 0 -}}

--- a/layouts/partials/head/config.html
+++ b/layouts/partials/head/config.html
@@ -5,7 +5,8 @@
 {{- $code_block := .Site.Params.code_block -}}
 {{- $i18n_languages := .Site.Languages -}}
 {{- $base_url := .Site.BaseURL -}}
-{{- $siteConfig := dict "icon_font" $icon_font "clipboard" $clipboard "outdate" $outdate "anchor_icon" $anchor_icon "code_block" $code_block "base" $base_url -}}
+{{- $anchor := .Site.Params.anchor -}}
+{{- $siteConfig := dict "icon_font" $icon_font "clipboard" $clipboard "outdate" $outdate "anchor_icon" $anchor_icon "code_block" $code_block "base" $base_url "anchor" $anchor -}}
 {{- if hugo.IsMultilingual -}}
 {{- $siteConfig = merge $siteConfig (dict "i18n_languages" $i18n_languages) -}}
 {{- end -}}


### PR DESCRIPTION
## 改动概述

为文章正文添加段落锚点功能，支持对任意块级元素（段落、列表项、引用等）添加可点击的锚点链接。

## 动机

目前仅标题（h1-h6）支持锚点定位，实际使用中经常需要直接链接到特定段落或列表项（如参考文献、脚注等），这个改动填补了这个空白。

## 改动内容

- `assets/js/anchor.ts` — 新增客户端脚本，注入锚点 id 和锚点图标
- `assets/css/partials/article.scss` — 新增 `.paragraph-anchor` 样式
- `layouts/partials/head/config.html` — 将 `anchor` 配置暴露到 siteConfig
- `config/_default/params.yml` — 新增 `anchor` 配置区块

## 使用方式

在 `params.yml` 中启用：

```yaml
# Paragraph anchor
# 为文章正文中的段落和列表项注入可跳转的锚点链接
# 使用方式：在 Markdown 中写 {#anchor-xxx}，对应元素会获得 id="anchor-xxx" 并显示锚点图标
anchor:
  # 显式锚点
  explicit: 
    # 是否启用显式锚点：解析 Markdown 中 {#anchor-xxx} 语法
    enable: true
    # 锚点占位符：显式锚点匹配的模式（无需修改，除非与正文内容冲突）
    marker: "{#anchor-"
  # 自动锚点
  auto:
  # 是否启用自动锚点：为直接子段落自动生成 id（从文本内容派生）
    enable: false
    # 自动锚点的 id 最大长度，超出则截断（仅 auto=true 时生效）
    length: 60
```

在 Markdown 中使用：
```markdown
- [参考文献1](url) {#anchor-ref1}
- [参考文献2](url) {#anchor-ref2}
```

渲染后对应` <li> `元素会获得 id="anchor-ref1" 并显示锚点图标，点击可复制链接或跳转。

## 测试
本地 hugo server 测试通过，锚点图标正常显示，点击链接可正确跳转。
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/9e1ce366-e768-4058-aac8-77ea596dfe99" />
