### PR TITLE
Fix capsule rendering on term pages when only_show_capsule_in_index is enabled

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -18,7 +18,7 @@
   {{- else -}}
     {{- $paginator = .Paginate .Pages -}}
   {{- end -}}
-  
+
   {{- $sortedPages := $paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}
   {{- if eq $sort_config "weight" -}}
     {{- $sortedPages = $paginator.Pages.ByWeight -}}
@@ -34,7 +34,7 @@
     data-aos="{{ .Site.Params.animation.options.archive.whole }}"
   >
     {{- if .Site.Params.only_show_capsule_in_index -}}
-      {{- if eq .Paginator.PageNumber 1 -}}
+      {{- if eq .Kind "taxonomy" -}}
         {{- partialCached "archives.html" . -}}
       {{- end -}}
     {{- else -}}


### PR DESCRIPTION
This PR addresses the behavior described in #112.

The capsule is currently rendered on the first page of term pages due to:

```
.Paginator.PageNumber == 1
```

Since term pages also have PageNumber == 1, this causes the capsule to appear on /tags/<tag>/ page 1.

This change replaces the condition with:

```
.Kind == "taxonomy"
```

Result:
- Capsule only appears on taxonomy index pages (/tags/, /categories/)
- Not shown on term pages (including page 1)

Let me know if this aligns with the intended behavior.