### PR TITLE
新增 spoiler (剧透/遮罩) 短代码

### DIFF
--- a/assets/css/spoiler.scss
+++ b/assets/css/spoiler.scss
@@ -1,0 +1,25 @@
+.spoiler {
+  background: var(--color-default);
+  color: var(--color-default);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: 0.2s;
+
+  &:hover,
+  &:active {
+    color: #fff;
+  }
+}
+
+[data-theme="dark"] {
+  .spoiler {
+    background: var(--color-wrap);
+    color: var(--color-wrap);
+
+    &:hover,
+    &:active {
+      color: var(--color-default);
+    }
+  }
+}

--- a/assets/css/spoiler.scss
+++ b/assets/css/spoiler.scss
@@ -1,6 +1,6 @@
 .spoiler {
-  background: var(--color-default);
-  color: var(--color-default);
+  background: #666;
+  color: #666;
   cursor: pointer;
   padding: 2px 6px;
   border-radius: 4px;
@@ -14,12 +14,12 @@
 
 [data-theme="dark"] {
   .spoiler {
-    background: var(--color-wrap);
-    color: var(--color-wrap);
+    background: #555;
+    color: #555;
 
     &:hover,
     &:active {
-      color: var(--color-default);
+      color: #fff;
     }
   }
 }

--- a/layouts/shortcodes/spoiler.html
+++ b/layouts/shortcodes/spoiler.html
@@ -1,0 +1,3 @@
+<span class="spoiler">{{ .Inner | .Page.RenderString }}</span>
+
+{{- partial "helpers/scss.html" (dict "source" "css/spoiler.scss" "temp" "spoiler.scss" "target" "css/spoiler.css" "ctx" . "async" true) -}}


### PR DESCRIPTION
新增`spoiler`短代码，用于在文章中隐藏剧透内容，桌面端鼠标悬停或移动端点击时才会显示文字。

### 使用方法

```md
这是一段{{< spoiler >}}剧透文字{{< /spoiler }}
```

### 效果

[https://kuqilin.github.io/post/spoilertest_shortcode/](https://kuqilin.github.io/post/spoilertest_shortcode/)