### PR TITLE
新增 exclude 排除贴文/目录 出现在特定部分

### DIFF
--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -183,6 +183,26 @@ rss:
   showFullContent: false # output full content or description
   showCopyright: false   # If true, add copyright to the end of article.
 
+# Hide posts from individual surfaces
+# Each key takes a list of content path prefixes, matched against the page's
+# logical path, so it keeps working when `permalinks` remaps the URL.
+# A single post can opt out through its front matter instead:
+#   exclude: [home, rss]   # a list of surface names
+#   exclude: all           # every surface
+# To hide a post everywhere, prefer Hugo's own `_build.list`; this option is for
+# posts that should stay visible on some surfaces and not others.
+exclude:
+  home:                 # the post list on the home page
+    # - /post/repost/
+  archive:              # the archive page
+  taxonomy:             # category and tag term pages
+  categories:           # category term pages only (adds to taxonomy)
+  tags:                 # tag term pages only (adds to taxonomy)
+  widget:               # sidebar widgets, sidebar counters and footer counters
+  search:               # the Algolia index
+  rss:                  # the RSS feed
+  sitemap:              # the sitemap (only hides posts; other pages stay)
+
 # Sort order configuration
 # Available values: default, date, date-reverse, weight, weight-reverse
 # default: hugo's default sort order for page collections, see https://gohugo.io/quick-reference/page-collections/#sort

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -1,6 +1,6 @@
 {{- $limit := 1000 -}}
 [
-  {{- range $index, $entry := where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections -}}
+  {{- range $index, $entry := partialCached "helpers/posts.html" (dict "ctx" . "surface" "search") "search" .Site.Language.Lang -}}
   {{ if $index }}, {{ end }}
   {
     "objectID": "{{ sha1 .RelPermalink }}",

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -16,6 +16,8 @@
   {{- $pages = where $pages "Language.Lang" $currentLanguage }}
 {{- end }}
 
+{{- $pages = partial "helpers/posts.html" (dict "ctx" . "surface" "rss" "pages" $pages) }}
+
 {{- $pages = $pages.ByLastmod.Reverse }}
 {{- $limit := .Site.Params.rss.limit | default 10 }}
 {{- if ge $limit 1 }}
@@ -35,7 +37,7 @@
     <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>
     {{ end }}
     <copyright>{{ $copyright }}</copyright>
-    {{ if not .Date.IsZero }}
+    {{ if and (not .Date.IsZero) $pages }}
     <lastBuildDate>{{ (index $pages 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{ end }}
     {{ with .OutputFormats.Get "RSS" }}

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,25 @@
+{{- /* posts hidden from the sitemap surface are dropped; every other page
+     (sections, terms, about, ...) keeps its place */ -}}
+{{- $keep := slice -}}
+{{- range partialCached "helpers/posts.html" (dict "ctx" . "surface" "sitemap") "sitemap" .Site.Language.Lang -}}
+  {{- $keep = $keep | append .RelPermalink -}}
+{{- end -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range where .Pages "Sitemap.Disable" "ne" true }}
+    {{- if and .Permalink (or (not (in .Site.Params.mainSections .Section)) (in $keep .RelPermalink)) -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .AllTranslations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Locale }}"
+                href="{{ .Permalink }}"
+                />{{ end }}{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -12,11 +12,19 @@
   {{- with $.Site.Params.paginate.archive -}}
     {{- $pageSize = . -}}
   {{- end -}}
+  {{- /* a term page gets its own surface (categories or tags), which also
+       inherits every taxonomy exclusion; the taxonomy index page keeps the
+       umbrella surface */ -}}
+  {{- $surface := "taxonomy" -}}
+  {{- if eq .Kind "term" -}}
+    {{- $surface = .Data.Plural -}}
+  {{- end -}}
+  {{- $posts := partial "helpers/posts.html" (dict "ctx" . "surface" $surface "pages" .Pages) -}}
   {{- $paginator := "" -}}
   {{- if gt $pageSize 0 -}}
-    {{- $paginator = .Paginate .Pages $pageSize -}}
+    {{- $paginator = .Paginate $posts $pageSize -}}
   {{- else -}}
-    {{- $paginator = .Paginate .Pages -}}
+    {{- $paginator = .Paginate $posts -}}
   {{- end -}}
 
   {{- $sortedPages := $paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,4 +1,11 @@
 {{- define "main" -}}
+  {{- /* drop terms left without a single visible post, keep the original
+       term page order */ -}}
+  {{- $terms := partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" .Data.Plural "surface" "taxonomy") .Data.Plural "taxonomy" .Site.Language.Lang -}}
+  {{- $keep := slice -}}
+  {{- range $terms -}}
+    {{- $keep = $keep | append .page.RelPermalink -}}
+  {{- end -}}
   <div
     class="archives-outer-wrap"
     data-aos="{{ .Site.Params.animation.options.archive.whole }}"
@@ -11,24 +18,26 @@
       {{ end }}"
     >
       {{- range .Pages -}}
-        <div
-          class="{{ if eq $.Name "Tags" }}
-            archives-tag-list-item
-          {{ else }}
-            archives-category-list-item
-          {{ end }}"
-          data-aos="{{ $.Site.Params.animation.options.archive.tag }}"
-        >
-          <a
+        {{- if in $keep .RelPermalink -}}
+          <div
             class="{{ if eq $.Name "Tags" }}
-              archives-tag-list-link
+              archives-tag-list-item
             {{ else }}
-              archives-category-list-link
+              archives-category-list-item
             {{ end }}"
-            href="{{ .RelPermalink }}"
-            >{{ .LinkTitle }}</a
+            data-aos="{{ $.Site.Params.animation.options.archive.tag }}"
           >
-        </div>
+            <a
+              class="{{ if eq $.Name "Tags" }}
+                archives-tag-list-link
+              {{ else }}
+                archives-category-list-link
+              {{ end }}"
+              href="{{ .RelPermalink }}"
+              >{{ .LinkTitle }}</a
+            >
+          </div>
+        {{- end -}}
       {{- end -}}
     </div>
   </div>

--- a/layouts/archives/section.html
+++ b/layouts/archives/section.html
@@ -4,11 +4,12 @@
   {{- with $.Site.Params.paginate.archive -}}
     {{- $pageSize = . -}}
   {{- end -}}
+  {{- $posts := partialCached "helpers/posts.html" (dict "ctx" . "surface" "archive") "archive" .Site.Language.Lang -}}
   {{- $paginator := "" -}}
   {{- if gt $pageSize 0 -}}
-    {{- $paginator = .Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) $pageSize -}}
+    {{- $paginator = .Paginate $posts $pageSize -}}
   {{- else -}}
-    {{- $paginator = .Paginate (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) -}}
+    {{- $paginator = .Paginate $posts -}}
   {{- end -}}
   
   {{- $sortedPages := $paginator.Pages.GroupByDate .Site.Params.yearFormat "desc" -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,11 +4,12 @@
   {{- with $.Site.Params.paginate.post -}}
     {{- $pageSize = . -}}
   {{- end -}}
+  {{- $posts := partialCached "helpers/posts.html" (dict "ctx" . "surface" "home") "home" .Site.Language.Lang -}}
   {{- $paginator := "" -}}
   {{- if gt $pageSize 0 -}}
-    {{- $paginator = .Paginate (where .Site.RegularPages "Section" "in" .Site.Params.mainSections) $pageSize -}}
+    {{- $paginator = .Paginate $posts $pageSize -}}
   {{- else -}}
-    {{- $paginator = .Paginate (where .Site.RegularPages "Section" "in" .Site.Params.mainSections) -}}
+    {{- $paginator = .Paginate $posts -}}
   {{- end -}}
   {{- $sort_config := .Site.Params.sort_order.home -}}
   {{- if and (eq 1 $paginator.PageNumber) ($ctx.Site.Params.home_categories.enable) -}}
@@ -44,7 +45,11 @@
                 {{- end -}}
               {{- end -}}
               <h2>{{ $v.categories }}</h2>
-              <h3>{{ i18n "home_categories.count" (len (index $ctx.Site.Taxonomies.categories (lower $v.categories))) }}</h3>
+              {{- $count := 0 -}}
+              {{- with index $ctx.Site.Taxonomies.categories (lower $v.categories) -}}
+                {{- $count = len (intersect .Pages $posts) -}}
+              {{- end -}}
+              <h3>{{ i18n "home_categories.count" $count }}</h3>
             </div>
           </div>
         {{- end -}}

--- a/layouts/partials/archives.html
+++ b/layouts/partials/archives.html
@@ -1,23 +1,23 @@
 <div class="tag-wrap">
-  {{- range .Site.Taxonomies.tags -}}
+  {{- range partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" "tags" "surface" "archive") "tags" "archive" .Site.Language.Lang -}}
     <div
       class="archives-tag-list-item"
       data-aos="{{ $.Site.Params.animation.options.archive.tag }}"
     >
-      <a class="archives-tag-list-link" href="{{ .Page.RelPermalink }}"
-        >{{ .Page.Title }}</a
+      <a class="archives-tag-list-link" href="{{ .page.RelPermalink }}"
+        >{{ .page.Title }}</a
       >
     </div>
   {{- end -}}
 </div>
 <div class="category-wrap">
-  {{- range .Site.Taxonomies.categories -}}
+  {{- range partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" "categories" "surface" "archive") "categories" "archive" .Site.Language.Lang -}}
     <div
       class="archives-category-list-item"
       data-aos="{{ $.Site.Params.animation.options.archive.category }}"
     >
-      <a class="archives-category-list-link" href="{{ .Page.RelPermalink }}"
-        >{{ .Page.Title }}</a
+      <a class="archives-category-list-link" href="{{ .page.RelPermalink }}"
+        >{{ .page.Title }}</a
       >
     </div>
   {{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 {{- $totalWordCount := 0 -}}
 {{- $totalReadingTime := 0 -}}
-{{- $posts := (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) -}}
+{{- $posts := partialCached "helpers/posts.html" (dict "ctx" . "surface" "widget") "widget" .Site.Language.Lang -}}
 {{- range $posts -}}
   {{- $totalWordCount = add $totalWordCount .WordCount -}}
   {{- $totalReadingTime = add $totalReadingTime .ReadingTime -}}

--- a/layouts/partials/helpers/posts.html
+++ b/layouts/partials/helpers/posts.html
@@ -1,0 +1,88 @@
+{{- /*
+  Returns the post collection for a surface, with excluded posts removed.
+
+  Exclusions come from two independent places:
+
+    - Site params `exclude.<surface>`: a list of content path prefixes, matched
+      against `.Path`. Use this to hide a whole directory, e.g. "/post/repost/".
+      `.Path` is the logical content path, so it keeps working when `permalinks`
+      remaps the URL.
+    - Front matter `exclude`: a list of surface names, or the string "all".
+      Use this for a single post.
+
+  Hugo's native `_build.list` already hides a page from every collection at
+  once; this helper exists for the cases where a post should stay visible on
+  some surfaces and not others.
+
+  `categories` and `tags` are refinements of `taxonomy`: on a category term
+  page both `exclude: [taxonomy]` and `exclude: [categories]` apply, while
+  `exclude: [tags]` does not (and vice versa on a tag term page). The same
+  layering holds for the params keys `exclude.taxonomy` / `exclude.categories`
+  / `exclude.tags`.
+
+  The source collection keeps its original type when nothing is excluded, so
+  the common case costs one length comparison.
+
+  @param {page} ctx The page context.
+  @param {string} surface One of home, archive, taxonomy, categories, tags, widget, search, rss, sitemap.
+  @param {page.Pages} [pages] Source collection. Defaults to every page in mainSections.
+
+  @returns {page.Pages}
+
+  @example {{ $posts := partialCached "helpers/posts.html" (dict "ctx" . "surface" "home") "home" .Language.Lang }}
+*/ -}}
+{{- $ctx := .ctx -}}
+{{- $surface := .surface -}}
+{{- $pages := .pages -}}
+{{- if not (isset . "pages") -}}
+  {{- $pages = where $ctx.Site.RegularPages "Section" "in" $ctx.Site.Params.mainSections -}}
+{{- end -}}
+
+{{- $surfaces := slice $surface -}}
+{{- if in (slice "categories" "tags") $surface -}}
+  {{- $surfaces = $surfaces | append "taxonomy" -}}
+{{- end -}}
+
+{{- $prefixes := slice -}}
+{{- with $exclude := $ctx.Site.Params.exclude -}}
+  {{- range $s := $surfaces -}}
+    {{- with index $exclude $s -}}
+      {{- range . -}}
+        {{- $prefixes = $prefixes | append . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $excluded := slice -}}
+{{- range $pages -}}
+  {{- $page := . -}}
+  {{- $skip := false -}}
+  {{- with $page.Params.exclude -}}
+    {{- if eq . "all" -}}
+      {{- $skip = true -}}
+    {{- else -}}
+      {{- range $s := $surfaces -}}
+        {{- if in $page.Params.exclude $s -}}
+          {{- $skip = true -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $skip -}}
+    {{- range $prefixes -}}
+      {{- if hasPrefix $page.Path . -}}
+        {{- $skip = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $skip -}}
+    {{- $excluded = $excluded | append $page -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $excluded -}}
+  {{- $pages = complement . $pages -}}
+{{- end -}}
+
+{{- return $pages -}}

--- a/layouts/partials/helpers/taxonomy.html
+++ b/layouts/partials/helpers/taxonomy.html
@@ -1,0 +1,35 @@
+{{- /*
+  Returns the terms of a taxonomy for a surface, with excluded posts discounted.
+  Terms left without a single visible post are dropped, so a category whose
+  posts are all hidden disappears instead of showing a count of zero.
+
+  The intersect runs only when the surface actually excludes something, so an
+  unconfigured site pays one length comparison per taxonomy.
+
+  @param {page} ctx The page context.
+  @param {string} kind The taxonomy name, e.g. categories or tags.
+  @param {string} surface One of home, archive, taxonomy, categories, tags, widget, search, rss, sitemap.
+
+  @returns {slice} Slice of dicts, each with a `page` (the term page) and a `count`.
+
+  @example {{ $terms := partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" "tags" "surface" "widget") "tags" "widget" .Language.Lang }}
+*/ -}}
+
+{{- $ctx := .ctx -}}
+{{- $surface := .surface -}}
+{{- $visible := partialCached "helpers/posts.html" (dict "ctx" $ctx "surface" $surface) $surface $ctx.Site.Language.Lang -}}
+{{- $all := where $ctx.Site.RegularPages "Section" "in" $ctx.Site.Params.mainSections -}}
+{{- $isFiltered := lt (len $visible) (len $all) -}}
+
+{{- $result := slice -}}
+{{- range index $ctx.Site.Taxonomies .kind -}}
+  {{- $count := .Count -}}
+  {{- if $isFiltered -}}
+    {{- $count = len (intersect .Pages $visible) -}}
+  {{- end -}}
+  {{- if gt $count 0 -}}
+    {{- $result = $result | append (dict "page" .Page "count" $count) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $result -}}

--- a/layouts/partials/sidebar/commonBar.html
+++ b/layouts/partials/sidebar/commonBar.html
@@ -18,18 +18,18 @@
 <div class="sidebar-state">
   <div class="sidebar-state-article">
     <div>{{ i18n "sidebar.post" }}</div>
-    {{- $posts := (where .ctx.Page.Site.RegularPages "Section" "in" $params.mainSections) -}}
+    {{- $posts := partialCached "helpers/posts.html" (dict "ctx" .ctx "surface" "widget") "widget" .ctx.Site.Language.Lang -}}
     <div class="sidebar-state-number">{{ len $posts }}</div>
   </div>
   <a class="sidebar-state-category" href="{{ "categories/" | relLangURL }}" aria-label="sidebar-state-category-link">
     <div>{{ i18n "sidebar.category" }}</div>
     <div class="sidebar-state-number">
-      {{ len .ctx.Site.Taxonomies.categories }}
+      {{ len (partialCached "helpers/taxonomy.html" (dict "ctx" .ctx "kind" "categories" "surface" "widget") "categories" "widget" .ctx.Site.Language.Lang) }}
     </div>
   </a>
   <a class="sidebar-state-tag" href="{{ "tags/" | relLangURL }}" aria-label="sidebar-state-tag-link">
     <div>{{ i18n "sidebar.tag" }}</div>
-    <div class="sidebar-state-number">{{ len .ctx.Site.Taxonomies.tags }}</div>
+    <div class="sidebar-state-number">{{ len (partialCached "helpers/taxonomy.html" (dict "ctx" .ctx "kind" "tags" "surface" "widget") "tags" "widget" .ctx.Site.Language.Lang) }}</div>
   </a>
 </div>
 <div class="sidebar-social" {{ if not (or $showMenu $mobile) }}style="margin-bottom: 20px;"{{ end }}>

--- a/layouts/partials/widget/category.html
+++ b/layouts/partials/widget/category.html
@@ -1,24 +1,25 @@
-{{- if len .Site.Taxonomies.categories -}}
+{{- $terms := partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" "categories" "surface" "widget") "categories" "widget" .Site.Language.Lang -}}
+{{- with $terms -}}
   <div class="widget-wrapper">
     <div
       class="widget-wrap"
-      data-aos="{{ .Site.Params.animation.options.home.widget }}"
+      data-aos="{{ $.Site.Params.animation.options.home.widget }}"
     >
       <div style="display: flex; justify-content: space-between;">
         <h3 class="widget-title">{{ i18n "categories" }}</h3>
-        {{- if gt (len .Site.Taxonomies.categories) .Site.Params.category_limits -}}
+        {{- if gt (len .) $.Site.Params.category_limits -}}
           <a class="widget-link" href="{{ "categories/" | relLangURL }}">{{ i18n "more" }}</a>
         {{- end -}}
       </div>
       <div class="widget">
         <ul class="category-list">
           {{- $counter := 0 -}}
-          {{- range .Site.Taxonomies.categories -}}
+          {{- range . -}}
             {{- if lt $counter $.Site.Params.category_limits -}}
               <li class="category-list-item">
-                <a class="category-list-link" href="{{ .Page.RelPermalink }}" 
-                  title="{{ .Page.Title }}"
-                  >{{ .Page.Title }}</a
+                <a class="category-list-link" href="{{ .page.RelPermalink }}"
+                  title="{{ .page.Title }}"
+                  >{{ .page.Title }}</a
                 >
               </li>
               {{- $counter = add $counter 1 -}}

--- a/layouts/partials/widget/recent_posts.html
+++ b/layouts/partials/widget/recent_posts.html
@@ -1,14 +1,14 @@
-{{- if len .Site.Pages -}}
-  {{- $recentPosts := (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) | first .Site.Params.recent_posts_limits -}}
+{{- $recentPosts := (partialCached "helpers/posts.html" (dict "ctx" . "surface" "widget") "widget" .Site.Language.Lang) | first .Site.Params.recent_posts_limits -}}
+{{- with $recentPosts -}}
   <div class="widget-wrapper">
     <div
       class="widget-wrap"
-      data-aos="{{ .Site.Params.animation.options.home.widget }}"
+      data-aos="{{ $.Site.Params.animation.options.home.widget }}"
     >
       <h3 class="widget-title">{{ i18n "recent_posts" }}</h3>
       <div class="widget">
         <ul>
-          {{- range $recentPosts -}}
+          {{- range . -}}
             <li>
               <a href="{{ .Permalink | relURL }}" title="{{ .Title }}">{{ .Title }}</a>
             </li>

--- a/layouts/partials/widget/tag.html
+++ b/layouts/partials/widget/tag.html
@@ -1,28 +1,29 @@
-{{- if len .Site.Taxonomies.tags -}}
+{{- $terms := partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" "tags" "surface" "widget") "tags" "widget" .Site.Language.Lang -}}
+{{- with $terms -}}
   <div class="widget-wrapper">
     <div
       class="widget-wrap"
-      data-aos="{{ .Site.Params.animation.options.home.widget }}"
+      data-aos="{{ $.Site.Params.animation.options.home.widget }}"
     >
       <div style="display: flex; justify-content: space-between;">
         <h3 class="widget-title">{{ i18n "tags" }}</h3>
-        {{- if gt (len .Site.Taxonomies.tags) .Site.Params.tag_limits -}}
+        {{- if gt (len .) $.Site.Params.tag_limits -}}
           <a class="widget-link" href="{{ "tags/" | relLangURL }}">{{ i18n "more" }}</a>
         {{- end -}}
       </div>
       <div class="widget">
         <ul class="tag-list" itemprop="keywords">
           {{- $counter := 0 -}}
-          {{- range .Site.Taxonomies.tags -}}
+          {{- range . -}}
             {{- if lt $counter $.Site.Params.tag_limits -}}
             <li class="tag-item">
                 <a
                   class="tag-link"
-                  href="{{ .Page.RelPermalink }}"
-                  aria-label="{{ i18n "tag" }}: {{ .Page.Title }}"
-                  title="{{ .Page.Title }}"
+                  href="{{ .page.RelPermalink }}"
+                  aria-label="{{ i18n "tag" }}: {{ .page.Title }}"
+                  title="{{ .page.Title }}"
                 >
-                  {{ .Page.Title }}
+                  {{ .page.Title }}
                 </a>
               </li>
               {{- $counter = add $counter 1 -}}

--- a/layouts/partials/widget/tagcloud.html
+++ b/layouts/partials/widget/tagcloud.html
@@ -1,24 +1,25 @@
-{{- if len .Site.Taxonomies.tags -}}
+{{- $terms := partialCached "helpers/taxonomy.html" (dict "ctx" . "kind" "tags" "surface" "widget") "tags" "widget" .Site.Language.Lang -}}
+{{- $posts := partialCached "helpers/posts.html" (dict "ctx" . "surface" "widget") "widget" .Site.Language.Lang -}}
+{{- with $terms -}}
 <div class="widget-wrapper">
   <div
     class="widget-wrap"
-    data-aos="{{ .Site.Params.animation.options.home.widget }}"
+    data-aos="{{ $.Site.Params.animation.options.home.widget }}"
   >
     <h3 class="widget-title">{{ i18n "tagcloud" }}</h3>
-    {{- $posts := (where .Page.Site.RegularPages "Section" "in" .Site.Params.mainSections) -}}
     <div class="widget tagcloud">
       {{- $counter := 0 -}}
-      {{- range .Site.Taxonomies.tags -}}
+      {{- range . -}}
         {{- if lt $counter $.Site.Params.tagcloud_limits -}}
           {{- $weight := 10 -}}
           {{- if gt (len $posts) 0 -}}
-            {{- $weight = add 10 (mul 10 (div .Count (len $posts))) -}}
+            {{- $weight = add 10 (mul 10 (div .count (len $posts))) -}}
           {{- end -}}
           <a
             style="font-size:{{ $weight }}px"
-            href="{{ .Page.RelPermalink }}"
-            aria-label="{{ i18n "tag" }}: {{ .Page.Title }}"
-            >{{ .Page.Title }}</a
+            href="{{ .page.RelPermalink }}"
+            aria-label="{{ i18n "tag" }}: {{ .page.Title }}"
+            >{{ .page.Title }}</a
           >
           {{- $counter = add $counter 1 -}}
         {{- end -}}


### PR DESCRIPTION
exclude参数可以在单个文章中通过front matter使用

| front matter | 预期：隐藏于 |
|---|---|
| `exclude: [home]` | 首页列表 |
| `exclude: [archive]` | 归档页 |
| `exclude: [taxonomy]` | 分类页 + 标签页 |
| `exclude: [categories]` | 仅分类页 |
| `exclude: [tags]` | 仅标签页 |
| `exclude: [widget]` | 侧栏 widget、侧栏/页脚计数 |
| `exclude: [search]` | algolia.json |
| `exclude: [rss]` | RSS |
 `exclude: [sitemap]` | sitemap.xml（只藏文章，其余页面保留） |
 `exclude: all` | 所有 surface |

也可以在params.yml中隐藏指定目录
```yml
exclude:
  home:       ["/post/others/tests/params/home/"]
  archive:    ["/post/others/tests/params/archive/"]
  taxonomy:   ["/post/others/tests/params/taxonomy/"]
  categories: ["/post/others/tests/params/categories/"]
  tags:       ["/post/others/tests/params/tags/"]
  widget:     ["/post/others/tests/params/widget/"]
  search:     ["/post/others/tests/params/search/"]
  rss:        ["/post/others/tests/params/rss/"]
  sitemap:    ["/post/others/tests/params/sitemap/"]
```

通过Claude Opus 5以及GLM 5.3辅助完成